### PR TITLE
Re matching to follow scpi rules

### DIFF
--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -165,7 +165,7 @@ class BaseMocker(metaclass=MockerMetaClass):
         if scpi_string is None:
             self._call_delay = call_delay
         else:
-            self.__scpi_dict__[scpi_string].call_delay = call_delay
+            self.__scpi_dict__[reformat(scpi_string)].call_delay = call_delay
 
     @classmethod
     def scpi(cls, scpi_string: str) -> Callable:
@@ -174,7 +174,7 @@ class BaseMocker(metaclass=MockerMetaClass):
             return_type = handler.return_type
 
             if not isinstance(return_type, MockerMetaClass):
-                __tmp_scpi_dict__[scpi_string] = handler
+                __tmp_scpi_dict__[reformat(scpi_string)] = handler
                 return
 
             # The function being decorated itself returns a Mocker. This is very
@@ -199,7 +199,7 @@ class BaseMocker(metaclass=MockerMetaClass):
         handler = None
 
         for regex_pattern in self.__scpi_dict__:
-            search_result = re.match(make(regex_pattern), scpi_string, re.IGNORECASE)
+            search_result = re.match(reformat(regex_pattern), scpi_string, re.IGNORECASE)
             if search_result:
                 if not found:
                     found = True
@@ -225,5 +225,5 @@ class BaseMocker(metaclass=MockerMetaClass):
 scpi = BaseMocker.scpi
 
 
-def make(scpi_string_pattern: str) -> str:
+def reformat(scpi_string_pattern: str) -> str:
     return re.sub("(?P<chr>[A-Z])(?P<name>[a-z]+)", "\g<chr>(?:\g<name>)?", scpi_string_pattern)

--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -199,8 +199,11 @@ class BaseMocker(metaclass=MockerMetaClass):
         handler = None
 
         for regex_pattern in self.__scpi_dict__:
-            regex_pattern_reformated, replacements = reformat_scpi_patten(regex_pattern)
-            search_result = re.match(f'(?i){regex_pattern_reformated}', scpi_string)
+            replacements = {}
+            search_result = re.match(f'(?i){regex_pattern}', scpi_string)
+            if not search_result:
+                regex_pattern_short, replacements = shoten_scpi_patten(regex_pattern)
+                search_result = re.match(f'(?i){regex_pattern_short}', scpi_string)
             if search_result:
                 if not found:
                     found = True
@@ -228,7 +231,7 @@ class BaseMocker(metaclass=MockerMetaClass):
 scpi = BaseMocker.scpi
 
 
-def reformat_scpi_patten(scpi_patten):
+def shoten_scpi_patten(scpi_patten):
     replacements = {}
     verses = scpi_patten.split(':')
     for i in range(len(verses)):
@@ -237,14 +240,13 @@ def reformat_scpi_patten(scpi_patten):
             search_result = re.search('[a-z]', verse)
             if search_result:
                 replacements[i] = verse
-                loc = search_result.span()
-                verse = re.sub('[a-z]', '', verse)
-                new_verse = f'{verse[:loc[0]]}(.*){verse[loc[1]:]}'
-                verses[i] = new_verse
+                verses[i] = re.sub('[a-z]', '', verse)
     return ':'.join(verses), replacements
 
 
 def reformat_scpi_string(scpi_string, replacements):
+    if len(replacements) == 0:
+        return scpi_string
     verses = scpi_string.split(':')
     for i in range(len(verses)):
         if i in replacements:

--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -199,7 +199,7 @@ class BaseMocker(metaclass=MockerMetaClass):
         handler = None
 
         for regex_pattern in self.__scpi_dict__:
-            search_result = re.match(reformat(regex_pattern), scpi_string, re.IGNORECASE)
+            search_result = re.match(regex_pattern, scpi_string, re.IGNORECASE)
             if search_result:
                 if not found:
                     found = True

--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -199,17 +199,14 @@ class BaseMocker(metaclass=MockerMetaClass):
         handler = None
 
         for regex_pattern in self.__scpi_dict__:
-            replacements = {}
             search_result = re.match(f'(?i){regex_pattern}', scpi_string)
             if not search_result:
-                regex_pattern_short, replacements = shoten_scpi_patten(regex_pattern)
+                regex_pattern_short = shoten_scpi_patten(regex_pattern)
                 search_result = re.match(f'(?i){regex_pattern_short}', scpi_string)
             if search_result:
                 if not found:
                     found = True
                     handler = self.__scpi_dict__[regex_pattern]
-                    scpi_string_modified = reformat_scpi_string(scpi_string, replacements)
-                    search_result = re.match(f'(?i){regex_pattern}', scpi_string_modified)
                     args = search_result.groups()
                 else:
                     raise MockingError(
@@ -232,23 +229,11 @@ scpi = BaseMocker.scpi
 
 
 def shoten_scpi_patten(scpi_patten):
-    replacements = {}
     verses = scpi_patten.split(':')
     for i in range(len(verses)):
         verse = verses[i]
-        if verse.isalpha() and verse[0].isupper():
+        if verse and verse[0].isupper():
             search_result = re.search('[a-z]', verse)
             if search_result:
-                replacements[i] = verse
                 verses[i] = re.sub('[a-z]', '', verse)
-    return ':'.join(verses), replacements
-
-
-def reformat_scpi_string(scpi_string, replacements):
-    if len(replacements) == 0:
-        return scpi_string
-    verses = scpi_string.split(':')
-    for i in range(len(verses)):
-        if i in replacements:
-            verses[i] = replacements[i]
     return ':'.join(verses)

--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -199,10 +199,7 @@ class BaseMocker(metaclass=MockerMetaClass):
         handler = None
 
         for regex_pattern in self.__scpi_dict__:
-            search_result = re.match(f'(?i){regex_pattern}', scpi_string)
-            if not search_result:
-                regex_pattern_short = shoten_scpi_patten(regex_pattern)
-                search_result = re.match(f'(?i){regex_pattern_short}', scpi_string)
+            search_result = re.match(make(regex_pattern), scpi_string, re.IGNORECASE)
             if search_result:
                 if not found:
                     found = True
@@ -228,12 +225,5 @@ class BaseMocker(metaclass=MockerMetaClass):
 scpi = BaseMocker.scpi
 
 
-def shoten_scpi_patten(scpi_patten):
-    verses = scpi_patten.split(':')
-    for i in range(len(verses)):
-        verse = verses[i]
-        if verse and verse[0].isupper():
-            search_result = re.search('[a-z]', verse)
-            if search_result:
-                verses[i] = re.sub('[a-z]', '', verse)
-    return ':'.join(verses)
+def make(scpi_string_pattern: str) -> str:
+    return re.sub("(?P<chr>[A-Z])(?P<name>[a-z]+)", "\g<chr>(?:\g<name>)?", scpi_string_pattern)

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -13,7 +13,7 @@ def test_base_long_and_short_form_match():
     mocker.send(":instr:channel1:volt 12")
     mocker.send(":Instrument:channel2:voltage 13.4")
 
-    voltage = mocker.send(":inStrument:channel1:vOlTage?")
+    voltage = mocker.send(":inStrument:channel1:vOlT?")
     assert voltage == "12.0"
 
     voltage = mocker.send(":iNstR:channel2:volt?")

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -1,4 +1,19 @@
-from visa_mock.test.mock_instruments.instruments import Mocker1, Mocker2, Mocker3, Mocker4
+from visa_mock.test.mock_instruments.instruments import Mocker0, Mocker1, Mocker2, Mocker3, Mocker4
+
+
+def test_base_partial_match():
+    """
+    In Mocker0, "INSTRument" is used, but only the "INSTR" part is required. It's also NOT case-sensitive.
+    """
+    mocker = Mocker0()
+    mocker.send(":instr:channel1:volt 12")
+    mocker.send(":instr:channel2:volt 13.4")
+
+    voltage = mocker.send(":instr:channel1:volt?")
+    assert voltage == "12.0"
+
+    voltage = mocker.send(":instr:channel2:volt?")
+    assert voltage == "13.4"
 
 
 def test_base():

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -8,8 +8,6 @@ def test_base_long_and_short_form_match():
     They are also NOT case-sensitive. Same for the keyword "VOLTage".
 
     The user can use either the long form or the short form, but not partial.
-
-    The user should also use only the long form or the short form, but not mixed of the two.
     """
     mocker = Mocker0()
     mocker.send(":instr:channel1:volt 12")

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -5,15 +5,17 @@ from visa_mock.test.mock_instruments.instruments import Mocker0, Mocker1, Mocker
 def test_base_long_and_short_form_match():
     """
     In Mocker0, "INSTRument" is the long form, and "INSTR" is the short form.
-    They are also NOT case-sensitive.
+    They are also NOT case-sensitive. Same for the keyword "VOLTage".
 
     The user can use either the long form or the short form, but not partial.
+
+    The user should also use only the long form or the short form, but not mixed of the two.
     """
     mocker = Mocker0()
     mocker.send(":instr:channel1:volt 12")
-    mocker.send(":Instr:channel2:volt 13.4")
+    mocker.send(":Instrument:channel2:voltage 13.4")
 
-    voltage = mocker.send(":inStr:channel1:volt?")
+    voltage = mocker.send(":inStrument:channel1:vOlTage?")
     assert voltage == "12.0"
 
     voltage = mocker.send(":iNstR:channel2:volt?")

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -1,19 +1,26 @@
+import pytest
 from visa_mock.test.mock_instruments.instruments import Mocker0, Mocker1, Mocker2, Mocker3, Mocker4
 
 
-def test_base_partial_match():
+def test_base_long_and_short_form_match():
     """
-    In Mocker0, "INSTRument" is used, but only the "INSTR" part is required. It's also NOT case-sensitive.
+    In Mocker0, "INSTRument" is the long form, and "INSTR" is the short form.
+    They are also NOT case-sensitive.
+
+    The user can use either the long form or the short form, but not partial.
     """
     mocker = Mocker0()
     mocker.send(":instr:channel1:volt 12")
-    mocker.send(":instr:channel2:volt 13.4")
+    mocker.send(":Instr:channel2:volt 13.4")
 
-    voltage = mocker.send(":instr:channel1:volt?")
+    voltage = mocker.send(":inStr:channel1:volt?")
     assert voltage == "12.0"
 
-    voltage = mocker.send(":instr:channel2:volt?")
+    voltage = mocker.send(":iNstR:channel2:volt?")
     assert voltage == "13.4"
+
+    with pytest.raises(ValueError, match='Unknown SCPI command'):
+        voltage = mocker.send(":instru:channel2:volt?")
 
 
 def test_base():

--- a/visa_mock/test/mock_instruments/instruments.py
+++ b/visa_mock/test/mock_instruments/instruments.py
@@ -2,6 +2,28 @@ from collections import defaultdict
 from visa_mock.base.base_mocker import BaseMocker, scpi
 
 
+class Mocker0(BaseMocker):
+    """
+    A mocker class mocking a multi channel voltage source.
+    Voltages are zero by default
+
+    The upper case part in the scpi cmd is mandatory, while the
+    lower case potion is optional.
+    """
+
+    def __init__(self, call_delay: float = 0.0) -> None:
+        super().__init__(call_delay=call_delay)
+        self._voltage = defaultdict(lambda: 0.0)
+
+    @scpi(r":INSTRument:CHANNEL(.*):VOLT (.*)")
+    def _set_voltage(self, channel: int, value: float) -> None:
+        self._voltage[channel] = value
+
+    @scpi(r":INSTRument:CHANNEL(.*):VOLT\?")
+    def _get_voltage(self, channel: int) -> float:
+        return self._voltage[channel]
+
+
 class Mocker1(BaseMocker):
     """
     A mocker class mocking a multi channel voltage source.

--- a/visa_mock/test/mock_instruments/instruments.py
+++ b/visa_mock/test/mock_instruments/instruments.py
@@ -15,11 +15,11 @@ class Mocker0(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = defaultdict(lambda: 0.0)
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLT (.*)")
+    @scpi(r":INSTRument:CHANNEL(.*):VOLTage (.*)")
     def _set_voltage(self, channel: int, value: float) -> None:
         self._voltage[channel] = value
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLT\?")
+    @scpi(r":INSTRument:CHANNEL(.*):VOLTage\?")
     def _get_voltage(self, channel: int) -> float:
         return self._voltage[channel]
 


### PR DESCRIPTION
1. It may be better to use `re.match` instead of `re.search`. Because `re.match` checks for a match only at the beginning of the string, and it would limit the situations when there are multiple matches.

2. Now the program will match the long form or the short form, but not partial, same as the real instruments.

Once the changes are in, the following changes need to be made to the existing mock drivers:
- Always use the long form in the driver (aka. the same format in the user's guide)