### PR TITLE
To add compiled RE to the scpi_dict of SubModule

### DIFF
--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -173,8 +173,10 @@ class BaseMocker(metaclass=MockerMetaClass):
             handler = SCPIHandler.from_method(function)
             return_type = handler.return_type
 
+            regex = compile_regular_expression(scpi_string)
+
             if not isinstance(return_type, MockerMetaClass):
-                __tmp_scpi_dict__[compile_regular_expression(scpi_string)] = handler
+                __tmp_scpi_dict__[regex] = handler
                 return
 
             # The function being decorated itself returns a Mocker. This is very
@@ -185,8 +187,8 @@ class BaseMocker(metaclass=MockerMetaClass):
 
             SubModule = cast(MockerMetaClass, return_type)
 
-            for scpi_sub_string, sub_handler in SubModule.__scpi_dict__.items():
-                __tmp_scpi_dict__[scpi_string + scpi_sub_string] = SCPIHandler.combine(
+            for regex_sub_string, sub_handler in SubModule.__scpi_dict__.items():
+                __tmp_scpi_dict__[regex + regex_sub_string] = SCPIHandler.combine(
                     handler, sub_handler
                 )
 

--- a/visa_mock/test/base/test_base_class.py
+++ b/visa_mock/test/base/test_base_class.py
@@ -63,18 +63,30 @@ def test_one_of_each_kind():
 
 
 def test_modular_mock():
+    """
+    Note: In the definition of the MockerChannel, which was called in Mocker3, keyword "VOLTage"
+    was used. It means the user can use either the long form "voltage", or the short form "volt"
+    in the scpi string. (both are case in-sensitive)
+    """
 
     mocker3 = Mocker3()
-    mocker3.send(":CHANNEL1:VOLT 12")
+    # to use long form "voltage":
+    mocker3.send(":CHANNEL1:VOLTage 12")
+    # short form "volt":
     voltage = mocker3.send(":CHANNEL1:VOLT?")
     assert voltage == "12.0"
 
-    mocker3.send(":CHANNEL2:VOLT 13.4")
-    voltage = mocker3.send(":CHANNEL2:VOLT?")
+    mocker3.send(":channel2:volt 13.4")
+    voltage = mocker3.send(":channel2:voltage?")
     assert voltage == "13.4"
 
 
 def test_modular_2_mock():
+    """
+    Note: In the definition of Mocker4, keyword "INSTRument" was used. As a result, the user can use
+    either the long form "instrument" or the short form "instr", in addition to the "voltage"/"volt"
+    situation described in the test_modular_mock() above.
+    """
 
     mocker4 = Mocker4()
 
@@ -84,13 +96,16 @@ def test_modular_2_mock():
     voltage = mocker4.send(":INSTR1:CHANNEL1:VOLT?")
     assert voltage == "12.0"
 
-    voltage = mocker4.send(":INSTR1:CHANNEL2:VOLT?")
+    # to use long form "instrument" and "voltage", case in-sensitive:
+    voltage = mocker4.send(":INSTRument1:CHANNEL2:VOLTage?")
     assert voltage == "0"
     mocker4.send(":INSTR1:CHANNEL2:VOLT 13.4")
-    voltage = mocker4.send(":INSTR1:CHANNEL2:VOLT?")
+    # to use long form "voltage" only
+    voltage = mocker4.send(":INSTR1:CHANNEL2:VOLTage?")
     assert voltage == "13.4"
 
-    voltage = mocker4.send(":INSTR2:CHANNEL1:VOLT?")
+    # to use long form "instrument" only:
+    voltage = mocker4.send(":instrument2:CHANNEL1:VOLT?")
     assert voltage == "0"
     mocker4.send(":INSTR2:CHANNEL1:VOLT -12")
     voltage = mocker4.send(":INSTR2:CHANNEL1:VOLT?")

--- a/visa_mock/test/mock_instruments/instruments.py
+++ b/visa_mock/test/mock_instruments/instruments.py
@@ -68,11 +68,11 @@ class MockerChannel(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = 0
 
-    @scpi(r":VOLT (.*)")
+    @scpi(r":VOLTage (.*)")
     def _set_voltage(self, voltage: float) -> None:
         self._voltage = voltage
 
-    @scpi(r":VOLT\?")
+    @scpi(r":VOLTage\?")
     def _get_voltage(self) -> float:
         return self._voltage
 
@@ -100,7 +100,7 @@ class Mocker4(BaseMocker):
             2: Mocker3()
         }
 
-    @scpi(r":INSTR(.*)")
+    @scpi(r":INSTRument(.*)")
     def _channel(self, number: int) -> Mocker3:
         return self._instruments[number]
 


### PR DESCRIPTION
In this PR, scpi string is always modified to the correct format first, then added to the scpi_dict.

Test mocker and tests have also been modified to test the new changes.