### PR TITLE
use "SerialInstrument" instead of "Resource" for class "MockResource"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(requirements_fname) as fp:
 
 setup(
     name="pyvisa-mock",
-    version="0.5",
+    version="0.51",
     packages=find_packages(),
     python_requires='>=3.6.*',
     install_requires=install_requires,

--- a/visa_mock/base/high_level.py
+++ b/visa_mock/base/high_level.py
@@ -5,7 +5,9 @@ from typing_extensions import ClassVar
 from pyvisa import constants, highlevel, rname, errors
 from pyvisa.constants import InterfaceType
 from pyvisa.resources.resource import Resource
+from pyvisa.resources import SerialInstrument
 from pyvisa.rname import register_subclass, ResourceName
+from pyvisa.typing import VISASession
 
 from visa_mock.base.register import resources
 from visa_mock.base.session import Session
@@ -35,7 +37,7 @@ InterfaceType.mock = mock_constant
 
 
 @Resource.register(mock_constant, "INSTR")
-class MockResource(Resource):
+class MockResource(SerialInstrument):
 
     def read(self, **kwargs) -> str:
         reply, status_code = self.visalib.read(self.session)
@@ -126,7 +128,7 @@ class MockVisaLibrary(highlevel.VisaLibraryBase):
         """
         return self._sessions[session_idx].set_attribute(attribute, attribute_state)
 
-    def read(self, session_idx: int, count: int=None) -> Tuple[str, STATUS_CODE]:
+    def read(self, session_idx: int, count: int = None) -> Tuple[str, STATUS_CODE]:
         reply = self._sessions[session_idx].read()
         return reply, constants.StatusCode.success
 
@@ -143,3 +145,8 @@ class MockVisaLibrary(highlevel.VisaLibraryBase):
         to try in case that no argument is given.
         """
         return 'unset',
+
+    def flush(
+        self, session: VISASession, mask: constants.BufferOperation
+    ) -> None:
+        return None


### PR DESCRIPTION
In the resent QCoDeS release (0.19), there are the following changes:

(PR: https://github.com/QCoDeS/Qcodes/pull/2307  "Pyvisa 1.11 fix typing issues")
1. for qcodes/instrument/visa.py :
https://github.com/QCoDeS/Qcodes/commit/dbede88de7f522e0986ab96b4906e2f7838f1108
the "souce" has to be an instance of `MessageBasedResource`, which is a subclass of `Resource`

2. for qcodes/instrument_drivers/stahl/stahl.py :
https://github.com/QCoDeS/Qcodes/commit/8d7637f0fc50537dc53626fad4e27faafabc2d4e
`self.visa_handle` has to be an instance of `SerialInstrument`, which is a sublcass of `MessageBasedResource`.

Both the `souce` and `visa_handle` will be a instance of `MockResource` in our pyvisa-mock framework. Previously, `MockResource` is a subclass of `Resource`. To meet with the requirement above, `MockResource` needs to be a subclass of `MessageBasedResource` instead.

Meanwhile, the `MessageBasedResource` class is calling the `flush` method of its visalib, so the `MockVisaLibrary` needs to implement the `flush` method as well.
