### PR TITLE
Scpi strings are not regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,13 @@ class MockerChannel(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = 0
     
-    # Lets define handler functions. Notice how we can be 
-    # lazy in our regular expressions (using ".*"). The 
-    # typehints will be used to cast strings to the 
-    # required types
+    # Lets define handler functions. 
     
-    @scpi(r":VOLT (.*)") 
-    def _set_voltage(self, value: float) -> None:
-        self._voltage = value
+    @scpi(":VOLTage <voltage>") 
+    def _set_voltage(self, voltage: float) -> None:
+        self._voltage = voltage
     
-    @scpi(r":VOLT\?")
+    @scpi(":VOLTage?")
     def _get_voltage(self) -> float: 
         return self._voltage
 
@@ -43,14 +40,14 @@ class Mocker(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._channels = defaultdict(MockerChannel)
 
-    @scpi("\*IDN\?")
+    @scpi("*IDN?")
     def idn(self) -> str: 
         """
         'vendor', 'model', 'serial', 'firmware'
         """
         return "Mocker,testing,00000,0.01"
     
-    @scpi(r":INSTR:CHANNEL(.*)")
+    @scpi(":INSTRument:CHAnnel<channel>")
     def _get_channel(self, channel: int) -> MockerChannel:
         return self._channels[channel] 
         
@@ -59,5 +56,6 @@ register_resource("MOCK0::mock1::INSTR", Mocker())
 rc = ResourceManager(visa_library="@mock")
 res = rc.open_resource("MOCK0::mock1::INSTR")
 res.write(":INSTR:CHANNEL1:VOLT 2.3")
-reply = res.query(":INSTR:CHANNEL1:VOLT?")  # This should return '2.3'
+reply = res.query(":INSTR:CHA1:VOLT?")  # This should return '2.3'
+reply = res.query(":instrument:channel1:voltage?") # We can either use the short form or the long form
 ```

--- a/visa_mock/test/base/test_delays.py
+++ b/visa_mock/test/base/test_delays.py
@@ -25,7 +25,7 @@ def test_delay_on_instrument():
 def test_delay_on_command():
     call_delay = 2.0        # unit: [sec]
     mocker = Mocker1()
-    cmd_w_delay = ":INSTR:CHANNEL(.*):VOLT (.*)"
+    cmd_w_delay = ":INSTRument:CHANNEL<channel>:VOLTage <value>"
 
     # To introduce delay to one cmd only:
     mocker.set_call_delay(call_delay, cmd_w_delay)

--- a/visa_mock/test/mock_instruments/instruments.py
+++ b/visa_mock/test/mock_instruments/instruments.py
@@ -20,11 +20,11 @@ class Mocker0(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = defaultdict(lambda: 0.0)
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLTage (.*)")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage <value>")
     def _set_voltage(self, channel: int, value: float) -> None:
         self._voltage[channel] = value
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLTage\?")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage?")
     def _get_voltage(self, channel: int) -> float:
         return self._voltage[channel]
 
@@ -39,11 +39,11 @@ class Mocker1(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = defaultdict(lambda: 0.0)
 
-    @scpi(r":INSTR:CHANNEL(.*):VOLT (.*)")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage <value>")
     def _set_voltage(self, channel: int, value: float) -> None:
         self._voltage[channel] = value
 
-    @scpi(r":INSTR:CHANNEL(.*):VOLT\?")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage?")
     def _get_voltage(self, channel: int) -> float:
         return self._voltage[channel]
 
@@ -58,11 +58,11 @@ class Mocker2(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = defaultdict(lambda: 0.0)
 
-    @scpi(r":INSTR:CHANNEL(.*):VOLT (.*)")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage <value>")
     def _set_voltage(self, channel: int, value: float) -> None:
         self._voltage[channel] = value
 
-    @scpi(r":INSTR:CHANNEL(.*):VOLT\?")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage?")
     def _get_voltage(self, channel: int) -> float:
         return 2 * self._voltage[channel]
 
@@ -73,11 +73,11 @@ class MockerChannel(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage = 0
 
-    @scpi(r":VOLTage (.*)")
+    @scpi(":VOLTage <voltage>")
     def _set_voltage(self, voltage: float) -> None:
         self._voltage = voltage
 
-    @scpi(r":VOLTage\?")
+    @scpi(":VOLTage?")
     def _get_voltage(self) -> float:
         return self._voltage
 
@@ -91,7 +91,7 @@ class Mocker3(BaseMocker):
             2: MockerChannel()
         }
 
-    @scpi(r":CHANNEL(.*)")
+    @scpi(":CHANNEL<number>")
     def _channel(self, number: int) -> MockerChannel:
         return self._channels[number]
 
@@ -105,9 +105,9 @@ class Mocker4(BaseMocker):
             2: Mocker3()
         }
 
-    @scpi(r":INSTRument(.*)")
-    def _channel(self, number: int) -> Mocker3:
-        return self._instruments[number]
+    @scpi(":INSTRument<instrument_num>")
+    def _channel(self, instrument_num: int) -> Mocker3:
+        return self._instruments[instrument_num]
 
 
 class Mocker5(BaseMocker):
@@ -123,15 +123,15 @@ class Mocker5(BaseMocker):
         super().__init__(call_delay=call_delay)
         self._voltage: Dict[int, float] = defaultdict(lambda: 0.0)
 
-    @scpi(r'\*CLS')
+    @scpi(r'*CLS')
     def clear_stb(self) -> None:
         self.stb = 0
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLTage (.*)")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage <value>")
     def _set_voltage(self, channel: int, value: float) -> None:
         self._voltage[channel] = value
 
-    @scpi(r":INSTRument:CHANNEL(.*):VOLTage\?")
+    @scpi(":INSTRument:CHANNEL<channel>:VOLTage?")
     def _get_voltage(self, channel: int) -> float:
         return self._run_measurement(channel)
 
@@ -141,7 +141,7 @@ class Mocker5(BaseMocker):
         self.set_service_request_event()
         return self._voltage[channel]
 
-    @scpi(r":INSTRument:CHANNEL(.*):MEASure")
+    @scpi(":INSTRument:CHANNEL<channel>:MEASure")
     def _start_voltage_meas(self, channel: int) -> None:
         if self.stb & 0x40:
             # Don't start another measurement until the previous one is cleared.
@@ -152,7 +152,7 @@ class Mocker5(BaseMocker):
             daemon=True,
             ).start()
 
-    @scpi(r":INSTRument:CHANNEL(.*):REAd\?")
+    @scpi(":INSTRument:CHANNEL<channel>:REAd?")
     def _read_voltage_meas(self, channel: int) -> float:
         return self._voltage[channel]
 


### PR DESCRIPTION
SCPI strings do not have to be regular expressions. This makes programming mockers slightly easier. 

For instance, instead of 

```python
@scpi(r":INSTRument:CHAnnel(.*):VOLTage (.*)")
def _set_voltage(self, number: int, value: float): 
    pass 
``` 

we can write 

```python
@scpi(":INSTRument:CHAnnel<number>:VOLTage <value>")  # Copy-past from instrument manual
def _set_voltage(self, number: int, value: float): 
    pass 
```

Because scpi strings are no longer regular expressions, we do not have to escape characters like "?" and "*". Strings between '<' and '>' will become keyword arguments with which we call the handler method.  