### PR TITLE
Binary data

### DIFF
--- a/pyvisa_mock/base/base_mocker.py
+++ b/pyvisa_mock/base/base_mocker.py
@@ -321,7 +321,13 @@ class BaseMocker(metaclass=MockerMetaClass):
         else:
             time.sleep(self._call_delay)
 
-        return str(handler(self, *args, **kwargs))
+        resp = handler(self, *args, **kwargs)
+        if isinstance(resp, (bytes, bytearray)):
+            # Return binary data as-is
+            return resp
+        else:
+            # Cast to string for all others
+            return str(resp)
 
     """
     Event Support:

--- a/pyvisa_mock/base/high_level.py
+++ b/pyvisa_mock/base/high_level.py
@@ -370,7 +370,7 @@ class MockVisaLibrary(highlevel.VisaLibraryBase):
         return (stb_val, StatusCode.success)
 
     def read(self, session_idx: int, count: int = None) -> Tuple[str, STATUS_CODE]:
-        reply = self._sessions[session_idx].read()
+        reply = self._sessions[session_idx].read(count)
         return reply, StatusCode.success
 
     def write(self, session_idx: int, data: str) -> STATUS_CODE:

--- a/pyvisa_mock/base/session.py
+++ b/pyvisa_mock/base/session.py
@@ -154,8 +154,15 @@ class Session:
         if reply is not None:
             self._read_buffer = reply
 
-    def read(self) -> str:
-        return self._read_buffer
+    def read(self, count: int = None) -> str:
+        if count is None:
+            # Return everything
+            return self._read_buffer
+        else:
+            assert count >= 0
+            return_buffer = self._read_buffer[:count]
+            self._read_buffer = self._read_buffer[count:]
+            return return_buffer
 
     def ask(self, message: str):
         self.write(message)

--- a/pyvisa_mock/test/base/test_binary_data.py
+++ b/pyvisa_mock/test/base/test_binary_data.py
@@ -1,0 +1,60 @@
+from pyvisa import Resource, ResourceManager
+from pyvisa.resources import MessageBasedResource
+from pyvisa.util import to_ieee_block
+
+from pyvisa_mock.base.register import register_resources
+from pyvisa_mock.test.mock_instruments import instruments
+
+
+def test_read_bytes_from_bytes_response():
+    register_resources(instruments.resources)
+
+    rc = ResourceManager(visa_library="@mock")
+    resource: MessageBasedResource|Resource = rc.open_resource("MOCK0::mock7::INSTR")
+    resource.write("FETCh?")
+
+    data = resource.read_bytes(1)
+    assert data == b"1"
+
+    data = resource.read_bytes(10)
+    assert data == b".0,2.0,3.0"
+
+
+def test_read_bytes_from_bytearray_response(monkeypatch):
+    monkeypatch.setattr(instruments.Mocker7, "FETCH_DATA", bytearray(b"4.0,5.0,6.0"))
+
+    register_resources(instruments.resources)
+
+    rc = ResourceManager(visa_library="@mock")
+    resource: MessageBasedResource|Resource = rc.open_resource("MOCK0::mock7::INSTR")
+    resource.write("FETCh?")
+
+    data = resource.read_bytes(1)
+    assert data == b"4"
+
+    data = resource.read_bytes(10)
+    assert data == b".0,5.0,6.0"
+
+def test_query_binary_values(monkeypatch):
+    data = to_ieee_block([1.0, 2.0, 3.0])
+    monkeypatch.setattr(instruments.Mocker7, "FETCH_DATA", data)
+
+    register_resources(instruments.resources)
+    rc = ResourceManager(visa_library="@mock")
+    resource: MessageBasedResource|Resource = rc.open_resource("MOCK0::mock7::INSTR")
+
+    data = resource.query_binary_values("FETCh?")
+    assert data == [1.0, 2.0, 3.0]
+
+
+def test_read_binary_values(monkeypatch):
+    data = to_ieee_block([1.0, 2.0, 3.0])
+    monkeypatch.setattr(instruments.Mocker7, "FETCH_DATA", data)
+
+    register_resources(instruments.resources)
+    rc = ResourceManager(visa_library="@mock")
+    resource: MessageBasedResource|Resource = rc.open_resource("MOCK0::mock7::INSTR")
+    resource.write("FETCh?")
+
+    data = resource.read_binary_values()
+    assert data == [1.0, 2.0, 3.0]

--- a/pyvisa_mock/test/mock_instruments/instruments.py
+++ b/pyvisa_mock/test/mock_instruments/instruments.py
@@ -203,6 +203,19 @@ class Mocker6(BaseMocker):
         return MockerResponse.NOT_OKAY_BOARDER.value
 
 
+class Mocker7(BaseMocker):
+    """
+    A mocker class that returns binary data.
+
+    Based on Agilent
+    """
+    FETCH_DATA = b"1.0,2.0,3.0"
+
+    @scpi("FETCh?")
+    def fetch(self) -> bytes:
+        return self.FETCH_DATA
+
+
 resources = {
     "MOCK0::mock1::INSTR": Mocker1(),
     "MOCK0::mock2::INSTR": Mocker2(),
@@ -210,4 +223,5 @@ resources = {
     "MOCK0::mock4::INSTR": Mocker4(),
     "MOCK0::mock5::INSTR": Mocker5(),
     "MOCK0::mock6::INSTR": Mocker6(),
+    "MOCK0::mock7::INSTR": Mocker7(),
 }


### PR DESCRIPTION
We use PyVISA's `read_bytes()` to read measurement data from our devices (Keysight Agilent 34980A), but `read_bytes()` is not properly supported by the mock device.

Changes added:
- support for reading partial responses (the `count` parameter for `read_bytes()`)
- support for returning binary data
- some tests for binary data methods