### PR TITLE
Fix high-level library `write`

### DIFF
--- a/pyvisa_mock/base/high_level.py
+++ b/pyvisa_mock/base/high_level.py
@@ -373,9 +373,9 @@ class MockVisaLibrary(highlevel.VisaLibraryBase):
         reply = self._sessions[session_idx].read(count)
         return reply, StatusCode.success
 
-    def write(self, session_idx: int, data: str) -> STATUS_CODE:
+    def write(self, session_idx: int, data: str) -> Tuple[int, STATUS_CODE]:
         self._sessions[session_idx].write(data)
-        return StatusCode.success
+        return len(data), StatusCode.success
 
     def clear(self, session_idx: int) -> None:
         return None


### PR DESCRIPTION
As indicated in the [PyVISA docs](https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html#pyvisa.highlevel.VisaLibraryBase.write), the 'high-level' implementation of `write` should return both the amount of bytes written and the status code. Currently, pyvisa-mock returns only the status code, which raises an issue, for instance, here: https://github.com/pyvisa/pyvisa/blob/5ca5e6a1fb19b23c5cedc284115021686822d57b/pyvisa/resources/messagebased.py#L173

This PR fixes the `write` implementation, and adapts the signature to the correct return value.